### PR TITLE
feat: add filter-by-ID support to ParentView with contextual banner a…

### DIFF
--- a/scoutbase.client/src/components/admin/common/Sidebar.jsx
+++ b/scoutbase.client/src/components/admin/common/Sidebar.jsx
@@ -2,8 +2,7 @@
 import {
     FileText, UserPlus, Users, BarChart2, ChevronRight, ChevronDown, Mail,
     FolderKanban, Cake, Repeat, Download, User, MapPin, Menu, ArrowLeft,
-    LogOut, Home, CalendarCheck, QrCode, Flag, BookOpenCheck, Shield, Megaphone, FolderSymlink
-
+    LogOut, Home, CalendarCheck, QrCode, Flag, BookOpenCheck, Shield, Megaphone, FolderSymlink, FileCheck2
 } from 'lucide-react';
 
 import { can } from "@/utils/roleUtils";
@@ -67,6 +66,7 @@ export default function Sidebar({ onNavigate, userInfo, actingAsGroupId, actingA
                 { key: 'report-age', label: 'Age Report', icon: <Cake size={16} /> },
                 { key: 'report-transitions', label: 'Linking History', icon: <Repeat size={16} /> },
                 { key: 'report-full-export', label: 'Full Export', icon: <Download size={16} /> },
+                { key: 'report-data-quality', label: 'Data Quality', icon: <FileCheck2 size={16} /> }
             ]
         },
 

--- a/scoutbase.client/src/components/admin/reports/ReportDataQuality.jsx
+++ b/scoutbase.client/src/components/admin/reports/ReportDataQuality.jsx
@@ -1,0 +1,168 @@
+﻿import { useEffect, useState } from 'react';
+import { PageWrapper, PageTitle, PrimaryButton, CompactSelect } from '@/components/common/SharedStyles';
+import { supabase } from '@/lib/supabaseClient';
+import { downloadCSV } from '@/utils/exportUtils';
+import { FileCheck2 } from 'lucide-react';
+
+function ReportCard({ title, description, data, filename, fixPathBase }) {
+    if (!data || data.length === 0) return null;
+
+    return (
+        <div style={{ border: '1px solid #ccc', borderRadius: '6px', padding: '1rem', marginBottom: '1rem' }}>
+            <h3 style={{ marginBottom: '0.5rem' }}>{title}</h3>
+            <p style={{ fontSize: '0.9rem', marginBottom: '1rem' }}>{description}</p>
+
+            <ul style={{ marginBottom: '1rem' }}>
+                {data.slice(0, 5).map((item) => (
+                    <li key={item.id}>
+                        {item.name || item.email || `ID: ${item.id}`} &nbsp;
+                        <a href={`${fixPathBase}?id=${item.id}`} style={{ fontSize: '0.8rem', color: '#0F5BA4' }}>Fix</a>
+                    </li>
+                ))}
+                {data.length > 5 && <li>...and {data.length - 5} more</li>}
+            </ul>
+
+            <PrimaryButton onClick={() => downloadCSV(data, filename)}>Download CSV</PrimaryButton>
+        </div>
+    );
+}
+
+
+export default function DataQualityPage({ groupId }) {
+    const [sectionFilter, setSectionFilter] = useState('');
+    const [reports, setReports] = useState({
+        missingPrimaryParent: [],
+        unlinkedParents: [],
+        missingPatrol: [],
+        patrolsWithoutYouth: [],
+        patrolsMissingLeaders: [],
+        youthWithoutTransitions: [],
+        parentsMissingContact: []
+    });
+
+    useEffect(() => {
+        const loadReports = async () => {
+            const [pyp, parents, youth, patrols, transitions] = await Promise.all([
+                supabase.from('parent_youth').select('parent_id, youth_id, is_primary'),
+                supabase.from('parent').select('id, name, email, phone, group_id').eq('group_id', groupId),
+                supabase.from('youth').select('id, name, section, patrol_id, group_id').eq('group_id', groupId),
+                supabase.from('patrols').select('id, name, group_id, section').eq('group_id', groupId),
+                supabase.from('youth_transitions').select('id, youth_id')
+            ]);
+
+            const primaryLinks = new Set(pyp.data.filter(p => p.is_primary).map(p => p.youth_id));
+            const youthWithNoPrimary = youth.data.filter(y => !primaryLinks.has(y.id));
+
+            const parentsWithLinks = new Set(pyp.data.map(p => p.parent_id));
+            const unlinkedParents = parents.data.filter(p => !parentsWithLinks.has(p.id));
+
+            const youthWithNoPatrol = youth.data.filter(y => !y.patrol_id);
+            const patrolsWithYouth = new Set(youth.data.map(y => y.patrol_id).filter(Boolean));
+            const patrolsNoYouth = patrols.data.filter(p => !patrolsWithYouth.has(p.id));
+
+            const youthRoles = await supabase.from('youth').select('patrol_id, rank');
+            const patrolsMissingPLAPL = patrols.data.filter(p => {
+                const members = youthRoles.data.filter(y => y.patrol_id === p.id);
+                return !members.some(m => m.rank === 'PL') || !members.some(m => m.rank === 'APL');
+            });
+
+            const youthIds = new Set(transitions.data.map(t => t.youth_id));
+            const noTransition = youth.data.filter(y => !youthIds.has(y.id));
+
+            const noContactParents = parents.data.filter(p => !p.email && !p.phone);
+
+            setReports({
+                missingPrimaryParent: youthWithNoPrimary,
+                unlinkedParents,
+                missingPatrol: youthWithNoPatrol,
+                patrolsWithoutYouth: patrolsNoYouth,
+                patrolsMissingLeaders: patrolsMissingPLAPL,
+                youthWithoutTransitions: noTransition,
+                parentsMissingContact: noContactParents
+            });
+        };
+
+        if (groupId) loadReports();
+    }, [groupId]);
+
+    const filterBySection = (items) =>
+        sectionFilter === '' ? items : items.filter(item => item.section === sectionFilter);
+
+    return (
+        <PageWrapper>
+            <PageTitle>
+                <FileCheck2 size={24} style={{ marginRight: '0.5rem' }} />Data Quality Reports</PageTitle>
+            <p style={{ marginBottom: '1rem', color: '#444' }}>Check for missing links or important data gaps in your group records.</p>
+
+            <div style={{ marginBottom: '2rem' }}>
+                <label htmlFor="sectionFilter" style={{ marginRight: '0.5rem' }}>Filter by section:</label>
+                <CompactSelect
+                    id="sectionFilter"
+                    value={sectionFilter}
+                    onChange={(e) => setSectionFilter(e.target.value)}
+                >
+                    <option value="">All</option>
+                    <option value="Joeys">Joeys</option>
+                    <option value="Cubs">Cubs</option>
+                    <option value="Scouts">Scouts</option>
+                    <option value="Venturers">Venturers</option>
+                </CompactSelect>
+            </div>
+
+            <ReportCard
+                title="Youth Missing Primary Parent"
+                description="These youth have no parent marked as primary contact."
+                data={filterBySection(reports.missingPrimaryParent)}
+                filename="youth_missing_primary"
+                fixPathBase="/admin/add-youth" // ✅ direct path for youth
+            />
+            <ReportCard
+                title="Parents Without Linked Youth"
+                description="These parents are not linked to any youth."
+                data={reports.unlinkedParents}
+                filename="unlinked_parents"
+                fixPathBase="/admin/add-parent"
+            />
+
+            <ReportCard
+                title="Youth Not Assigned to a Patrol"
+                description="These youth do not have a patrol assigned."
+                data={filterBySection(reports.missingPatrol)}
+                filename="youth_no_patrol"
+                fixPathBase="/admin/add-youth"
+            />
+
+            <ReportCard
+                title="Patrols Without Youth"
+                description="These patrols have no youth assigned to them."
+                data={filterBySection(reports.patrolsWithoutYouth)}
+                filename="patrols_no_youth"
+                fixPathBase="/admin/patrol-management"
+            />
+
+            <ReportCard
+                title="Patrols Missing PL or APL"
+                description="These patrols are missing either a Patrol Leader or Assistant Patrol Leader."
+                data={filterBySection(reports.patrolsMissingLeaders)}
+                filename="patrols_missing_leaders"
+                fixPathBase="/admin/patrol-management"
+            />
+
+            <ReportCard
+                title="Youth Without Any Transitions"
+                description="These youth do not have any entries in the transition history."
+                data={filterBySection(reports.youthWithoutTransitions)}
+                filename="youth_no_transitions"
+                fixPathBase="/admin/add-youth"
+            />
+
+            <ReportCard
+                title="Parents Missing Email or Phone"
+                description="These parents have no email or phone number on record."
+                data={reports.parentsMissingContact}
+                filename="parents_missing_contact"
+                fixPathBase="/admin/add-parent"
+            />
+        </PageWrapper>
+    );
+}

--- a/scoutbase.client/src/pages/AdminPage.jsx
+++ b/scoutbase.client/src/pages/AdminPage.jsx
@@ -48,6 +48,7 @@ import ReportAttendanceView from '@/components/admin/reports/ReportAttendanceVie
 import InspectionPage from '@/components/admin/inspections/InspectionPage';
 import GroupQRCode from '@/components/admin/GroupQRCode';
 import ReportTransitionHistory from '@/components/admin/reports/ReportTransitionHistory';
+import ReportDataQuality from '@/components/admin/reports/ReportDataQuality';
 
 
 
@@ -174,6 +175,8 @@ export default function AdminPage() {
                 return <ParentHeaderLinks groupId={activeGroupId} />;
             case 'report-transitions':  
                 return <ReportTransitionHistory groupId={userInfo.group_id} userInfo={userInfo} />;
+            case 'report-data-quality':
+				return <ReportDataQuality groupId={userInfo.group_id} userInfo={userInfo} />;
             default:
                 if (userInfo?.role === 'Super Admin') {
                     return <SuperAdminDashboard key={`${actingAsAdmin}-${activeGroupId}`} />;


### PR DESCRIPTION
…nd delete handling

- Support URL query param `?id=` to filter ParentView by parent ID
- Show banner when filtered, including parent name and clear filter button
- Auto-clear filter and reload list when filtered parent is deleted
- Display success message when parent is deleted
- Minor UI polish on search and filter interactions