### PR TITLE
fix(auth): prevent duplicate audit logs from useTerrainUser in React …

### DIFF
--- a/scoutbase.client/src/components/admin/reports/ReportAttendanceView.jsx
+++ b/scoutbase.client/src/components/admin/reports/ReportAttendanceView.jsx
@@ -192,10 +192,7 @@ export default function AttendanceView({
     const totalSignedIn = filteredAttendance.filter(r => r.signIn).length;
     const totalSignedOut = filteredAttendance.filter(r => r.signOut).length;
     useEffect(() => {
-        console.log("📅 Date changed:", selectedDate);
-        console.log("👥 Youth List:", youthList);
-        console.log("✅ Filtered Attendance:", filteredAttendance);
-        console.log("📊 Pie Data:", pieData);
+
     }, [selectedDate, youthList, filteredAttendance, pieData]);
 
     return (


### PR DESCRIPTION
…Strict Mode

- Added sessionStorage + useRef safeguard to prevent duplicate 'admin_login' logs
- Deferred audit logging via setTimeout to avoid React dev-mode double invoke
- Ensures clean audit trail with only one login event per session