### PR TITLE
feat(parent-app): Parent portal improvements (grouped youth, signers …

### DIFF
--- a/scoutbase.client/api/server.js
+++ b/scoutbase.client/api/server.js
@@ -1,0 +1,137 @@
+﻿import express from 'express';
+import cors from 'cors';
+import dotenv from 'dotenv';
+import { createClient } from '@supabase/supabase-js';
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import 'dotenv/config';
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+console.log('SUPABASE_URL loaded:', process.env.SUPABASE_URL);
+
+const supabase = createClient(
+    process.env.SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const normalizeMobile = (input) => input.replace(/\D+/g, '');
+
+app.post('/api/loginParent', async (req, res) => {
+    console.log('🔔 [POST] /api/loginParent', req.body);
+
+    const { identifier, enteredPin, groupId } = req.body;
+    if (!identifier || !enteredPin || !groupId) {
+        console.warn('⚠️ Missing login fields');
+        return res.status(400).json({ error: 'Missing fields' });
+    }
+
+    const trimmed = identifier.trim();
+    const isPhone = /^\d{8,}$/.test(trimmed.replace(/\s+/g, ''));
+
+    // Fetch all parents in group with auth fields
+    const { data: parents, error } = await supabase
+        .from('parent')
+        .select('id, name, phone, pin_hash, group_id, failed_attempts, locked')
+        .eq('group_id', groupId);
+
+    if (error) {
+        console.error('❌ Error fetching parents:', error);
+        return res.status(500).json({ error: 'Database error' });
+    }
+
+    if (!parents || parents.length === 0) {
+        console.warn('⚠️ No parents found in group');
+        return res.status(401).json({ error: 'Invalid name or PIN' });
+    }
+
+    const match = parents.find(p =>
+        isPhone
+            ? normalizeMobile(p.phone) === normalizeMobile(trimmed)
+            : p.name?.trim().toLowerCase() === trimmed.toLowerCase()
+    );
+
+    if (!match) {
+        console.warn('❌ No matching parent found');
+        return res.status(401).json({ error: 'Invalid name or PIN' });
+    }
+
+    console.log(`🔍 Attempting login for ${match.name} (${match.phone})`);
+
+    if (!match.pin_hash) {
+        console.warn('❌ No stored hash for PIN');
+        return res.status(401).json({ error: 'Invalid name or PIN' });
+    }
+
+    if (match.locked) {
+        console.warn('🔒 Account is locked');
+        return res.status(403).json({
+            error: 'Account locked after 5 failed attempts. Please contact a leader.',
+        });
+    }
+
+    const isValid = await bcrypt.compare(enteredPin, match.pin_hash);
+
+    if (!isValid) {
+        const attempts = (match.failed_attempts || 0) + 1;
+        const locked = attempts >= 5;
+
+        console.warn(`❌ Invalid PIN - attempts: ${attempts}`);
+
+        const { error: updateError } = await supabase
+            .from('parent')
+            .update({ failed_attempts: attempts, locked })
+            .eq('id', match.id);
+
+        if (updateError) {
+            console.error('⚠️ Error updating failed_attempts:', updateError);
+        } else {
+            console.log(`📌 Updated failed_attempts=${attempts}, locked=${locked}`);
+        }
+
+        return res.status(401).json({
+            error: locked
+                ? 'Account locked after 5 failed attempts. Please contact a leader.'
+                : `Incorrect PIN. ${5 - attempts} attempt(s) left.`,
+        });
+    }
+
+    // ✅ Valid PIN
+    console.log(`✅ Successful login for ${match.name}`);
+
+    const { error: resetError } = await supabase
+        .from('parent')
+        .update({ failed_attempts: 0 })
+        .eq('id', match.id);
+
+    if (resetError) {
+        console.warn('⚠️ Failed to reset failed_attempts:', resetError);
+    }
+
+    const token = jwt.sign(
+        {
+            sub: match.id,
+            role: 'authenticated',
+            app_role: 'parent',
+            group_id: match.group_id
+        },
+        process.env.SUPABASE_JWT_SECRET,
+        { expiresIn: '4h' }
+    );
+
+    return res.json({
+        token,
+        parent: {
+            id: match.id,
+            name: match.name,
+            phone: match.phone,
+            group_id: match.group_id
+        }
+    });
+});
+
+app.listen(3001, () => {
+    console.log('🚀 Local API server running at http://localhost:3001');
+});

--- a/scoutbase.client/package-lock.json
+++ b/scoutbase.client/package-lock.json
@@ -27,6 +27,7 @@
         "react-qrcode-logo": "^3.0.0",
         "react-quill-new": "^3.4.6",
         "react-router-dom": "^7.5.3",
+        "react-swipeable": "^7.0.2",
         "recharts": "^2.15.2",
         "resend": "^4.3.0",
         "styled-components": "^6.1.17",
@@ -4290,6 +4291,15 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-swipeable": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-7.0.2.tgz",
+      "integrity": "sha512-v1Qx1l+aC2fdxKa9aKJiaU/ZxmJ5o98RMoFwUqAAzVWUcxgfHFXDDruCKXhw6zIYXm6V64JiHgP9f6mlME5l8w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17 || ^18 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/react-transition-group": {

--- a/scoutbase.client/package.json
+++ b/scoutbase.client/package.json
@@ -29,6 +29,7 @@
     "react-qrcode-logo": "^3.0.0",
     "react-quill-new": "^3.4.6",
     "react-router-dom": "^7.5.3",
+    "react-swipeable": "^7.0.2",
     "recharts": "^2.15.2",
     "resend": "^4.3.0",
     "styled-components": "^6.1.17",

--- a/scoutbase.client/src/components/parent/NotificationsPage.jsx
+++ b/scoutbase.client/src/components/parent/NotificationsPage.jsx
@@ -80,7 +80,7 @@ export default function NotificationsPage() {
 
             <TabList style={{ marginBottom: '1rem' }}>
                 <TabButton onClick={() => setTab('active')} isActive={tab === 'active'}>Active</TabButton>
-                <TabButton onClick={() => setTab('archived')} isActive={tab === 'archived'}>Archived</TabButton>
+                <TabButton onClick={() => setTab('archived')} isActive={tab === 'archived'}>Read</TabButton>
             </TabList>
 
             {loading ? (
@@ -106,7 +106,7 @@ export default function NotificationsPage() {
                             </div>
                             <div style={{ textAlign: 'right' }}>
                                 <SecondaryButton onClick={() => toggleArchive(n.id, true)}>
-                                    Archive
+									Mark as Read
                                 </SecondaryButton>
                             </div>
                         </div>
@@ -134,7 +134,7 @@ export default function NotificationsPage() {
                         </div>
                         <div style={{ textAlign: 'right' }}>
                             <SecondaryButton onClick={() => toggleArchive(n.id, false)}>
-                                Unarchive
+								Unmark as Read
                             </SecondaryButton>
                         </div>
                     </div>

--- a/scoutbase.client/src/components/parent/ParentCalendar.jsx
+++ b/scoutbase.client/src/components/parent/ParentCalendar.jsx
@@ -8,6 +8,7 @@ import {
 } from 'react-big-calendar';
 import moment from 'moment';
 import 'react-big-calendar/lib/css/react-big-calendar.css';
+import { useSwipeable } from 'react-swipeable';
 
 const localizer = momentLocalizer(moment);
 
@@ -88,6 +89,22 @@ export default function ParentCalendar({ feedUrl }) {
         ? events
         : events.filter(e => e.category === categoryFilter);
 
+    function changeMonth(offset) {
+        setDate(prev => {
+            const m = moment(prev).add(offset, 'months');
+            return m.toDate();
+        });
+    }
+
+    // Set up swipe handlers
+    const handlers = useSwipeable({
+        onSwipedLeft: () => changeMonth(1),
+        onSwipedRight: () => changeMonth(-1),
+        delta: 30, // Minimum distance(px) for a swipe
+        trackMouse: true // allows desktop drag
+    });
+
+
     return (
         <>
             {/* Legend & Filter */}
@@ -119,7 +136,7 @@ export default function ParentCalendar({ feedUrl }) {
             </div>
 
             {/* Calendar with working Month/Agenda toggle */}
-            <div style={{ height: 600 }}>
+            <div style={{ height: 600 }} {...handlers}>
                 <Calendar
                     localizer={localizer}
                     events={filtered}
@@ -130,11 +147,14 @@ export default function ParentCalendar({ feedUrl }) {
                     defaultView="month"
                     date={date}
                     onNavigate={setDate}
-                    view={view}              // ← controlled view
-                    onView={setView}         // ← must provide this
+                    view={view}
+                    onView={setView}
                     onSelectEvent={setSelectedEvent}
                     style={{ height: '100%' }}
                 />
+            </div>
+            <div style={{ textAlign: 'center', fontSize: '0.95rem', color: '#888', margin: '0.5rem 0' }}>
+                Swipe left or right to change months
             </div>
 
             {/* Event Details Modal */}

--- a/scoutbase.client/src/version.js
+++ b/scoutbase.client/src/version.js
@@ -1,6 +1,6 @@
 // version.js
 export const appVersion = {
-	version: '1.3.8'
+	version: '1.3.9'
 
 
 };


### PR DESCRIPTION
…modal, swipeable calendar)

- Group youth attendance list by "Primary Child" and "Other Children" on the parent side
- Sort youth alphabetically within each group for easier selection
- Update backend fetch to ensure is_primary is present on youth records
- Add "Who can sign in/out my child?" button and modal to parent profile page
  - Modal lists each primary child and all approved parents who can sign them in/out
  - Added instructional message: "To add or remove an approved adult, please see a leader."
- Add swipe gesture support to ParentCalendar using react-swipeable
  - Users can now swipe left/right to navigate months
  - Added hint message for mobile users about swiping

Minor fixes and UI improvements throughout for clarity and user experience.